### PR TITLE
Multiple tag blocklist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "ut1_blocklist"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "tempfile",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["text-processing", ]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+log = "0.4.17"
 tempfile = "3.2.0"
 thiserror = "1.0.29"
 url = "2.2.2"

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -1,10 +1,10 @@
-/*! Blocklists.
+/*! Single tag blocklist
 
 Contains basic filtering code and constructors.
 
 Filtering methods can be used on [Url]s.
 
-!*/
+*/
 use std::{
     collections::HashSet,
     fs::File,
@@ -32,7 +32,6 @@ pub struct Blocklist {
 
 impl Blocklist {
     /// Create a new Blocklist of provided kind.
-    ///
     pub fn new(kind: String, domains: HashSet<String>, urls: HashSet<String>) -> Self {
         Self {
             kind,

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -1,6 +1,8 @@
 /*! Single tag blocklist
 
-Contains basic filtering code and constructors.
+Contains links and a **single** tag.
+
+The underlying datastructure is a [HashSet].
 
 Filtering methods can be used on [Url]s.
 
@@ -56,7 +58,6 @@ impl Blocklist {
     }
 
     /// create a blocklist from specified kind and folder.
-    ///
     /// It will look for  `path/of/the/folder/kind`.
     pub fn with_folder(kind: String, folder: &Path) -> Result<Self, Error> {
         let mut file_path = PathBuf::from(folder);

--- a/src/blocklist_multi.rs
+++ b/src/blocklist_multi.rs
@@ -4,6 +4,37 @@
 //! For example, you may have the website `foo.com` that is both in A and B blocklists, and as such you'd like the blocklist to return `["A", "B"]`.
 //!
 //! Building might be slower than using the other blocklist available here, though.
+//!
+//! ## Directory structure
+//! The directory should have a number of subdirs, which in turn should have `domains` and `urls` files.
+//! The easiest way of using this is to get the whole [UT1 Blacklists](https://dsi.ut-capitole.fr/blacklists/index_en.php) archive,
+//! to decompress it and to point to the decompressed folder. **Be careful though, as some blocklists are also compressed (like `adult/domains.gz`)**
+/*!
+    ```text
+    ├── README
+    ├── ads -> publicite
+    ├── adult
+    │   ├── domains
+    │   ├── domains.24733
+    │   ├── domains.9309
+    │   ├── expressions
+    │   ├── urls
+    │   ├── usage
+    │   └── very_restrictive_expression
+    ├── aggressive -> agressif
+    ├── agressif
+    │   ├── domains
+    │   ├── expressions
+    │   ├── urls
+    │   └── usage
+    ├── arjel
+    │   ├── domains
+    │   └── usage
+    ├── associations_religieuses
+    │   ├── domains
+    │   └── usage
+    ```
+*/
 use std::{
     collections::{HashMap, HashSet},
     fs::File,
@@ -15,6 +46,7 @@ use crate::error::Ut1Error;
 use url::{Position, Url};
 
 // TODO: replace owned strings by refs to a (static?) tag.
+/// Domain and URL blocklist
 pub struct Blocklist {
     domains: HashMap<String, Vec<String>>,
     urls: HashMap<Url, Vec<String>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,4 @@ pub mod multibl;
 
 pub use blocklist::Blocklist;
 pub use error::Ut1Error as Error;
+pub use multibl::Blocklist as MultipleBlocklist;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 #![doc = include_str!("../README.md")]
 
 pub mod blocklist;
+pub mod blocklist_multi;
 mod error;
-pub mod multibl;
 
 pub use blocklist::Blocklist;
+pub use blocklist_multi::Blocklist as MultipleBlocklist;
 pub use error::Ut1Error as Error;
-pub use multibl::Blocklist as MultipleBlocklist;


### PR DESCRIPTION
Exports what's necessary to use the multiple tag blocklist, where one URL/domain can lead to multiple tags.